### PR TITLE
Add idspace declaration for DPBO

### DIFF
--- a/dpbo.obo
+++ b/dpbo.obo
@@ -11,6 +11,7 @@ remark: creator: Dominik Brilhaus <dominik.brilhaus<-at->hhu.de>
 remark: creator: Hajira Jabeen <hajira.jabeen<-at->uni-koeln.de>
 remark: curator: Kathryn Dumschott <k.dumschott@fz-juelich.de>
 remark: curator: Stella Eggels <s.eggels@fz-juelich.de>
+idspace: DPBO https://purl.org/nfdi4plants/ontology/dpbo/DPBO_ "DataPLANT Biology Ontology"
 ontology: dpbo
 property_value: http://purl.org/dc/elements/1.1/creator "https://orcid.org/0000-0001-9021-3197" xsd:string
 property_value: http://purl.org/dc/elements/1.1/creator "https://orcid.org/0000-0003-1476-2121" xsd:string


### PR DESCRIPTION
This makes any conversion from OBO to OWL or downstream use of this artifact aware of what the correct URI expansion of DPBO terms are. Without this, you'll get expansion to fake OBO PURLs like http://purl.obolibrary.org/obo/DPBO_1234567